### PR TITLE
Pangolin Mask Param Bugfix

### DIFF
--- a/server.py
+++ b/server.py
@@ -541,7 +541,7 @@ def run_splice_prediction_tool(tool_name):
         if tool_name == "spliceai":
             results = get_spliceai_scores(variant, genome_version, distance_param, mask_param, use_precomputed_scores)
         elif tool_name == "pangolin":
-            pangolin_mask_param = "True" if mask_param == "1" else "False"
+            pangolin_mask_param = "True" if mask_param == 1 else "False"
             results = get_pangolin_scores(variant, genome_version, distance_param, pangolin_mask_param, use_precomputed_scores)
         else:
             raise ValueError(f"Invalid tool_name: {tool_name}")


### PR DESCRIPTION
Small fix for when checking `mask_param` for pangolin predictions where it is incorrectly checking a string version of "1" but it is already converted to an int above in https://github.com/broadinstitute/SpliceAI-lookup/blob/master/server.py#L525.

This bug is causing the web app to always return "raw" pangolin scores even if "masked" is selected.