### PR TITLE
Reimplemented survey link button

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,9 +208,22 @@
                                             <i style="margin-left:20px" class="question circle outline icon" data-position="right center" data-content="Illumina provides pre-computed SpliceAI scores for all SNPs and small InDels within Gencode v24 canonical transcripts. If 'yes' is selected here, the server will quickly check these pre-computed files to see if it can avoid the relatively slow step of running the SpliceAI model. Even with 'yes' selected, it will still run the model if it finds that the pre-computed files don't contain the variant. Selecting 'no' will cause the server to always skip the pre-computed files and run the model. The benefit of skipping the pre-computed files is that, although the scores may take longer, they will always be computed for Gencode v38 transcripts and will include ENSG and ENST ids in addition to the gene name."></i>
                                         </div-->
                                     </div>
-                                    <div class="three wide column">
-                                        <button id="submit-button" class="ui primary button" style="margin-bottom: 15px">Submit</button>
+                                    <div class="three wide column" style="padding-right: 1.5rem">
+                                        <button id="submit-button" class="ui primary button right floated" style="margin-bottom: 15px">Submit</button>
                                     </div>
+                                </div>
+                                <div class="row">
+                                  <div class="twelve wide column">
+                                    <div class="field">
+                                      While you're waiting for your results...
+                                      <br />
+                                      <b>Help us to make SpliceAI Lookup even better!</b>
+                                      <i class="question circle outline icon" data-position="right center" data-content="This fairly short survey (~3-5mins) will help us understand what existing features you use and get information on what we should add, such as the highly-requested in-frame vs out-of-frame calculations. We'll be rolling out some of these features over the next few months, so keep an eye out!"></i>
+                                    </div>
+                                  </div>
+                                  <div class="four wide column" style="padding-right: 1.5rem">
+                                    <button id="survey" class="ui button right floated" onclick="window.open('https://forms.gle/cppzxRamzeJQcHDS9','popup','width=800,height=800')" style="background-color:rgba(252, 207, 184, 1)">Open Survey</button> 
+                                  </div>
                                 </div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
                                         <button id="submit-button" class="ui primary button right floated" style="margin-bottom: 15px">Submit</button>
                                     </div>
                                 </div>
-                                <div class="row">
+                                <div id="survey" class="row">
                                   <div class="twelve wide column">
                                     <div class="field">
                                       While you're waiting for your results...
@@ -222,7 +222,7 @@
                                     </div>
                                   </div>
                                   <div class="four wide column" style="padding-right: 1.5rem">
-                                    <button id="survey" class="ui button right floated" onclick="window.open('https://forms.gle/cppzxRamzeJQcHDS9','popup','width=800,height=800')" style="background-color:rgba(252, 207, 184, 1)">Open Survey</button> 
+                                    <button class="ui button right floated" onclick="window.open('https://forms.gle/cppzxRamzeJQcHDS9','popup','width=800,height=800')" style="background-color:rgba(252, 207, 184, 1)">Open Survey</button> 
                                   </div>
                                 </div>
                             </div>
@@ -734,6 +734,7 @@
               $("#error-box").hide()
               $("#response-box").html(generateResultsTable(response))
               $("#response-box").show()
+              $("#survey").hide()
 
               // set url
               window.location.hash = "#" + $.param({


### PR DESCRIPTION
Reimplementation of the [SpiceAI Lookup Survey Feedback link](https://forms.gle/cppzxRamzeJQcHDS9).

An additional row was added underneath the variant submission area. 
![Screenshot 2023-07-12 at 2 56 29 pm](https://github.com/broadinstitute/SpliceAI-lookup/assets/33969604/f2951fdf-6c32-4d4b-b6de-35f2c46efc55)

Extra information about the survey is visible on the hover of the "?"
![Screenshot 2023-07-12 at 2 56 36 pm](https://github.com/broadinstitute/SpliceAI-lookup/assets/33969604/9529426d-acaf-4b75-aed4-e96b35e6964a)


Clicking "Open survey" will open a separate pop-up window linking to the survey.
![Screenshot 2023-07-12 at 2 56 53 pm](https://github.com/broadinstitute/SpliceAI-lookup/assets/33969604/ee09d4ae-0b7a-4536-9d86-78fe0c141c71)
