### PR TITLE
Pangolin multi-header bug fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
                   "</tr>"
 
                 if(scores.is_pangolin) {
-                    result = "<tr class='pangolin_header'><td style='white-space: nowrap'><b>Pangolin scores: <a href='https://genomebiology.biomedcentral.com/articles/10.1186/s13059-022-02664-4' target='_blank'><i class='question circle outline icon' data-position='right center' data-content='Pangolin scores are computed on the server by running the Pangolin model with the user-selected parameters (ie. max distance).'></i></a></b> </td><td></td><td></td><td></td><td></td></tr>" + result
+                    result = "<tr class='pangolin_header' style='display:none'><td style='white-space: nowrap'><b>Pangolin scores: <a href='https://genomebiology.biomedcentral.com/articles/10.1186/s13059-022-02664-4' target='_blank'><i class='question circle outline icon' data-position='right center' data-content='Pangolin scores are computed on the server by running the Pangolin model with the user-selected parameters (ie. max distance).'></i></a></b> </td><td></td><td></td><td></td><td></td></tr>" + result
                 }
                 return result
               }).join("") +
@@ -736,7 +736,6 @@
               $("#response-box").show()
               $("#survey").hide()
 
-              $('.pangolin_header').hide()
               $('.pangolin_header').eq(0).show(); // show only first occurence of pangolin header
 
               // set url

--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
                   "</tr>"
 
                 if(scores.is_pangolin) {
-                    result = "<tr><td style='white-space: nowrap'><b>Pangolin scores: <a href='https://genomebiology.biomedcentral.com/articles/10.1186/s13059-022-02664-4' target='_blank'><i class='question circle outline icon' data-position='right center' data-content='Pangolin scores are computed on the server by running the Pangolin model with the user-selected parameters (ie. max distance).'></i></a></b> </td><td></td><td></td><td></td><td></td></tr>" + result
+                    result = "<tr class='pangolin_header'><td style='white-space: nowrap'><b>Pangolin scores: <a href='https://genomebiology.biomedcentral.com/articles/10.1186/s13059-022-02664-4' target='_blank'><i class='question circle outline icon' data-position='right center' data-content='Pangolin scores are computed on the server by running the Pangolin model with the user-selected parameters (ie. max distance).'></i></a></b> </td><td></td><td></td><td></td><td></td></tr>" + result
                 }
                 return result
               }).join("") +
@@ -735,6 +735,9 @@
               $("#response-box").html(generateResultsTable(response))
               $("#response-box").show()
               $("#survey").hide()
+
+              $('.pangolin_header').hide()
+              $('.pangolin_header').eq(0).show(); // show only first occurence of pangolin header
 
               // set url
               window.location.hash = "#" + $.param({


### PR DESCRIPTION
Fixes https://github.com/broadinstitute/SpliceAI-lookup/issues/46

Previously, multiple pangolin headers were produced if there were multiple canonical transcripts. This error is demonstrated by: https://spliceailookup.broadinstitute.org/#variant=9-71852789-T-G&hg=37&distance=500&mask=0

The fix was implemented by adding a class to the header and setting display to none, then on return of results displaying the first occurrence of the class.

Before: 
![Screenshot 2023-07-14 at 3 44 39 pm](https://github.com/broadinstitute/SpliceAI-lookup/assets/33969604/43ebbb8a-9b17-4789-9f80-919ec490c242)

After: 
![Screenshot 2023-07-14 at 3 45 12 pm](https://github.com/broadinstitute/SpliceAI-lookup/assets/33969604/4fdd3786-24da-42ef-82ba-a99f8355eb50)