### PR TITLE
Dependency updates: keras and pyvcf3

### DIFF
--- a/google_cloud_run_services/docker/pangolin/Dockerfile
+++ b/google_cloud_run_services/docker/pangolin/Dockerfile
@@ -16,10 +16,7 @@ RUN python3 -m pip install torch==2.2.1+cpu -f https://download.pytorch.org/whl/
 RUN apt update && apt-get install --no-install-recommends -y build-essential libpq-dev
 
 COPY docker/pangolin/requirements.txt /
-RUN python3 -m pip install setuptools==57.5.0 \
-    && python3 -m pip install pyvcf>=0.6.8 \
-	&& python3 -m pip install --upgrade setuptools \
-	&& python3 -m pip install --upgrade -r /requirements.txt
+RUN python3 -m pip install --upgrade -r /requirements.txt
 
 RUN git clone https://github.com/bw2/Pangolin.git \
     && cd Pangolin \

--- a/google_cloud_run_services/docker/pangolin/requirements.txt
+++ b/google_cloud_run_services/docker/pangolin/requirements.txt
@@ -8,8 +8,7 @@ pandas
 gffutils
 biopython
 pyfastx
-pyvcf>=0.6.8    # if you get an installation error like "use_2to3 is invalid", downgrade to setuptools==57.5.0, install pyvcf, then upgrade setuptools.
-pangolin @ git+https://github.com/bw2/Pangolin     # if the latest version isn't being installed, clone the repo and install from the local directory by running python3 setup.py install
+PyVCF3>=1.0.3
 
 # sql
 psycopg2

--- a/google_cloud_run_services/docker/spliceai/Dockerfile
+++ b/google_cloud_run_services/docker/spliceai/Dockerfile
@@ -16,10 +16,7 @@ RUN python3 -m pip install tensorflow==2.16.1
 RUN apt update && apt-get install --no-install-recommends -y build-essential libpq-dev
 
 COPY docker/spliceai/requirements.txt /
-RUN python3 -m pip install setuptools==57.5.0 \
-    && python3 -m pip install pyvcf>=0.6.8 \
-	&& python3 -m pip install --upgrade setuptools \
-	&& python3 -m pip install --upgrade -r /requirements.txt
+RUN python3 -m pip install --upgrade -r /requirements.txt
 
 RUN git clone https://github.com/bw2/SpliceAI.git  \
     && cd SpliceAI \

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ redis
 gffutils
 biopython
 pyfastx
-pyvcf>=0.6.8    # if you get an installation error like "use_2to3 is invalid", downgrade to setuptools==57.5.0, install pyvcf, then upgrade setuptools. 
+PyVCF3>=1.0.3
 pangolin @ git+https://github.com/bw2/Pangolin     # if the latest version isn't being installed, clone the repo and install from the local directory by running python3 setup.py install

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==2.16.1
-keras==2.1.5
+keras>=3.0.0
 spliceai @ git+https://github.com/bw2/SpliceAI   # if the latest version isn't being installed, clone the repo and install from the local directory by running python3 setup.py install
 flask
 flask-cors


### PR DESCRIPTION
With re-pinning of tensorflow to a 2.16 series version, keras needs to be at least 3.0.0 (fixed in first commit).

Second commit addresses #74 by updating that dependency and removing the workaround of downgrading setuptools in the dockerfiles.