### PR TITLE
only run debug server if executing file directly (not when import)

### DIFF
--- a/google_cloud_run_services/server.py
+++ b/google_cloud_run_services/server.py
@@ -690,4 +690,5 @@ def log_event(name):
 def catch_all(path):
     return f"SpliceAI-lookup APIs: invalid endpoint {path}"
 
-app.run(debug=DEBUG, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+if '__main__' == __name__:
+    app.run(debug=DEBUG, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
In other words, don't start the debug server on import by a wsgi server like gunicorn...

This fixes an issue where gunicorn would only make one worker process despite the setting of concurrency, and where gunicorn processes would fail without '--preload' since multiple dev servers would try to listen to the same port.

I think this also lead to a secondary effect where I was getting strange sporadic errors from pyfaidx about chr1 not being in the fasta file or reference base not matching for queries when re-running the query would work... so I think those were concurrency-related since some pyfaidx operations do not appear to be thread-safe (thus requiring workers to be separate processes).